### PR TITLE
295886: Add pre variable group ref

### DIFF
--- a/.azuredevops/build.yaml
+++ b/.azuredevops/build.yaml
@@ -61,6 +61,7 @@ extends:
         - ffc-demo-payment-web-snd3
         - ffc-demo-payment-web-dev1
         - ffc-demo-payment-web-tst1
+        - ffc-demo-payment-web-pre1
       variables:
         - ffc-demo-payment-web-APPINSIGHTS-CONNECTIONSTRING 
         - ffc-demo-payment-web-COOKIE-PASSWORD 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-demo-payment-web",
-  "version": "1.19.18",
+  "version": "1.19.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-demo-payment-web",
-      "version": "1.19.18",
+      "version": "1.19.19",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@hapi/hapi": "21.3.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-demo-payment-web",
   "description": "Digital service mock to view scheduled payments for financial aid in the event a property subsides into mine shaft.",
-  "version": "1.19.18",
+  "version": "1.19.19",
   "homepage": "https://github.com/DEFRA/ffc-demo-payment-web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
As part of the trial ADP PRE deployment we noticed the variable group refs were missing from the application pipeline. This PR adds the variable group reference.